### PR TITLE
Inference: PreAllocate Inputs/Outputs for infer()

### DIFF
--- a/src/inference/Inference.hpp
+++ b/src/inference/Inference.hpp
@@ -19,33 +19,11 @@ namespace rune_vm_internal::inference {
         virtual void accept(TVisitor& visitor) noexcept = 0;
     };
 
-    struct TensorDescriptor {
-        typedef enum {
-          DataType__NoType = 0,
-          DataType__Float32 = 1,
-          DataType__Int32 = 2,
-          DataType__UInt8 = 3,
-          DataType__Int64 = 4,
-          DataType__String = 5,
-          DataType__Bool = 6,
-          DataType__Int16 = 7,
-          DataType__Complex64 = 8,
-          DataType__Int8 = 9,
-          DataType__Float16 = 10,
-          DataType__Float64 = 11,
-          DataType__Complex128 = 12,
-        } DataType;
-
-        std::vector<int> shape;
-        DataType dataType;
-
-        TensorDescriptor(const std::string &descriptorString);
-        size_t byteCount() const;
-    };
-
     struct IModel: IElement<rune_vm::VirtualInterface<IModel>, IVisitor> {
-        std::vector<TensorDescriptor> inputDescriptors;
-        std::vector<TensorDescriptor> outputDescriptors;
+        std::vector<rune_vm::DataView<const uint8_t>> inputs;
+        std::vector<rune_vm::DataView<uint8_t>> outputs;
+
+        static size_t tensorSize(const std::string &descriptorString);
     };
 
     struct IRuntime: rune_vm::VirtualInterface<IRuntime> {


### PR DESCRIPTION
And get rid of TensorDescriptor code that we no longer need.